### PR TITLE
Fix logging interfaces to match .NET abstractions and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,179 @@
-# Fable Logging
+# Fable.Logging
 
-Logging framework for Fable.Python. This library adds a logging
-framework to Fable. It is based on the .NET logging framework and adds
-several useful interfaces and classess such as:
+A cross-platform logging framework for [Fable](https://fable.io). It mirrors the
+.NET [Microsoft.Extensions.Logging](https://learn.microsoft.com/en-us/dotnet/core/extensions/logging)
+pattern with `ILogger`, `ILoggerFactory`, and `ILoggerProvider` interfaces, letting you
+write idiomatic logging code in F# that works across JavaScript, Python, and Erlang/BEAM.
 
-- `ILogger` interface
-- `ILoggerFactory` interface
-- `ILoggerProvider` interface
-- `Logger` class
+## Packages
 
-Loggers provided (Python):
+| Package | NuGet | Description |
+|---------|-------|-------------|
+| `Fable.Logging` | [![NuGet](https://img.shields.io/nuget/v/Fable.Logging.svg)](https://www.nuget.org/packages/Fable.Logging) | Core interfaces, LoggerFactory, ConsoleLogger, JS console logger |
+| `Fable.Logging.Structlog` | [![NuGet](https://img.shields.io/nuget/v/Fable.Logging.Structlog.svg)](https://www.nuget.org/packages/Fable.Logging.Structlog) | Python [structlog](https://www.structlog.org/) provider |
+| `Fable.Logging.Beam` | [![NuGet](https://img.shields.io/nuget/v/Fable.Logging.Beam.svg)](https://www.nuget.org/packages/Fable.Logging.Beam) | Erlang/OTP logger provider |
 
-- [Structlog](https://www.structlog.org/en/stable/)
+## Quick Start
 
-Loggers provided (JS):
+Create a logger factory, configure it with providers, and start logging:
 
-- PRs welcome
+```fsharp
+open Fable.Logging
+
+let factory =
+    LoggerFactory.Create(fun builder ->
+        builder.AddProvider(ConsoleLoggerProvider())
+        builder.SetMinimumLevel(LogLevel.Debug))
+
+let logger = factory.CreateLogger("MyApp.Service")
+
+logger.LogInformation("Application started")
+logger.LogDebug("Processing request for {UserId}", box 42)
+logger.LogError("Something went wrong")
+```
+
+## Platform-Specific Providers
+
+### JavaScript (console)
+
+The built-in JS logger maps log levels to the appropriate `console.*` methods
+(`console.debug`, `console.info`, `console.warn`, `console.error`).
+
+```fsharp
+open Fable.Logging
+open Fable.Logging.JS
+
+let factory =
+    LoggerFactory.Create(fun builder ->
+        builder.AddProvider(LoggerProvider()))
+
+let logger = factory.CreateLogger("MyApp")
+logger.LogInformation("Hello from {Platform}!", box "JavaScript")
+```
+
+### Python (structlog)
+
+Uses [structlog](https://www.structlog.org/) for structured logging with support for
+both console and JSON output.
+
+```fsharp
+open Fable.Logging
+open Fable.Logging.Structlog
+
+// Console output (human-readable)
+let factory =
+    LoggerFactory.Create(fun builder ->
+        builder.AddProvider(ConsoleLoggerProvider()))
+
+// JSON output (machine-readable)
+let jsonFactory =
+    LoggerFactory.Create(fun builder ->
+        builder.AddProvider(JsonLoggerProvider()))
+
+let logger = factory.CreateLogger("MyApp")
+logger.LogInformation("User {Name} logged in", box "Alice")
+```
+
+### Erlang/BEAM (OTP logger)
+
+Bridges to the OTP `logger` module for applications targeting the BEAM runtime.
+
+```fsharp
+open Fable.Logging
+open Fable.Logging.Beam
+
+let factory =
+    LoggerFactory.Create(fun builder ->
+        builder.AddProvider(LoggerProvider()))
+
+let logger = factory.CreateLogger("MyApp")
+logger.LogWarning("Connection pool running low: {Available} remaining", box 3)
+```
+
+## Log Levels
+
+Log levels match the .NET `LogLevel` enum:
+
+| Level | Value | Method | Description |
+|-------|-------|--------|-------------|
+| Trace | 0 | `LogTrace` | Most detailed messages, may contain sensitive data |
+| Debug | 1 | `LogDebug` | Debugging and development |
+| Information | 2 | `LogInformation` | General flow of the application |
+| Warning | 3 | `LogWarning` | Abnormal or unexpected events |
+| Error | 4 | `LogError` | Errors and exceptions |
+| Critical | 5 | `LogCritical` | Failures requiring immediate attention |
+| None | 6 | | Suppresses all logging |
+
+## Filtering
+
+Set a minimum log level to filter out less severe messages:
+
+```fsharp
+let factory =
+    LoggerFactory.Create(fun builder ->
+        builder.AddProvider(ConsoleLoggerProvider())
+        builder.SetMinimumLevel(LogLevel.Warning))
+
+let logger = factory.CreateLogger("MyApp")
+logger.LogDebug("This is filtered out")
+logger.LogWarning("This is logged")
+```
+
+## Message Templates
+
+Use named placeholders in log messages for structured logging. The placeholder names
+become keys in the structured log output, while values are substituted positionally:
+
+```fsharp
+logger.LogInformation("Order {OrderId} placed by {Customer}", box 1234, box "Alice")
+// Output: MyApp - Order 1234 placed by Alice
+```
+
+## Logging Exceptions
+
+```fsharp
+try
+    failwith "Something broke"
+with ex ->
+    logger.LogError("Operation failed", ex)
+```
+
+## Multiple Providers
+
+The factory dispatches log messages to all registered providers:
+
+```fsharp
+let factory =
+    LoggerFactory.Create(fun builder ->
+        builder.AddProvider(consoleProvider)
+        builder.AddProvider(jsonProvider))
+
+// Messages are sent to both providers
+let logger = factory.CreateLogger("MyApp")
+logger.LogInformation("This goes to all providers")
+```
+
+## Writing a Custom Provider
+
+Implement `ILoggerProvider` and `ILogger` to create your own logging backend:
+
+```fsharp
+open Fable.Logging
+
+type MyLogger(name: string) =
+    interface ILogger with
+        member _.Log(state: LogState) =
+            printfn "[%A] %s: %s" state.Level name state.Format
+
+        member _.IsEnabled(logLevel: LogLevel) = true
+        member _.BeginScope(_) = failwith "Not implemented"
+
+type MyLoggerProvider() =
+    interface ILoggerProvider with
+        member _.CreateLogger(name) = MyLogger(name)
+        member _.Dispose() = ()
+```
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/justfile
+++ b/justfile
@@ -46,11 +46,11 @@ test:
 
 # Format code with Fantomas
 format:
-    dotnet fantomas {{src_path}} -r
+    dotnet fantomas {{src_path}}
 
 # Check code formatting without making changes
 format-check:
-    dotnet fantomas {{src_path}} -r --check
+    dotnet fantomas {{src_path}} --check
 
 # Install .NET tools (Fable, Fantomas, etc.)
 setup:

--- a/src/Fable.Logging.Beam/BeamLogger.fs
+++ b/src/Fable.Logging.Beam/BeamLogger.fs
@@ -17,15 +17,12 @@ type Logger(name: string) =
                 | LogLevel.Debug -> Logger.logger.debug (message)
                 | LogLevel.Information -> Logger.logger.info (message)
                 | LogLevel.Warning -> Logger.logger.warning (message)
-                | LogLevel.Error ->
-                    match state.Exception with
-                    | Some _ -> Logger.logger.error (message)
-                    | None -> Logger.logger.error (message)
+                | LogLevel.Error -> Logger.logger.error (message)
                 | LogLevel.Critical -> Logger.logger.critical (message)
                 | _ -> Logger.logger.info (message)
 
         member x.IsEnabled(logLevel: LogLevel) = logLevel >= x.MinimumLevel
-        member _.BeginScope(_) = failwith "Not implemented"
+        member _.BeginScope(_) : System.IDisposable = failwith "Not implemented"
 
 type LoggerProvider() =
     interface ILoggerProvider with

--- a/src/Fable.Logging.Structlog/Structlog.fs
+++ b/src/Fable.Logging.Structlog/Structlog.fs
@@ -86,10 +86,11 @@ type Logger(name: string, processors: Processor list) =
                     | Some ex -> logger.Exception(message, dict [ "args", args ])
                     | None -> logger.Error(message, dict [ "args", args ])
                 | LogLevel.Critical -> logger.Critical(message, dict [ "args", args ])
+                | LogLevel.Trace -> logger.Debug(message, dict [ "args", args ])
                 | _ -> logger.Info(message, dict [ "args", args ])
 
         member x.IsEnabled(logLevel: LogLevel) = logLevel >= x.MinimumLevel
-        member x.BeginScope(var0) = failwith "Not implemented"
+        member x.BeginScope(_) : System.IDisposable = failwith "Not implemented"
 
 
 type ConsoleLogger(name) =

--- a/src/Fable.Logging/ConsoleLogger.fs
+++ b/src/Fable.Logging/ConsoleLogger.fs
@@ -5,21 +5,10 @@ open System
 type ConsoleLogger(name: string) =
     interface ILogger with
         member this.Log(state: LogState) =
-            let message = state.Format
-            let args = state.Args
-            let error = state.Exception
-            let level = state.Level
+            let message, _ = Common.translateFormat name state.Format state.Args
 
             let message =
-                match args with
-                | null
-                | [||] -> message
-                | _ -> String.Format(message, args)
-
-            let message =
-                let message, _ = Common.translateFormat name message args
-
-                match error with
+                match state.Exception with
                 | Some error ->
                     message
                     + Environment.NewLine
@@ -29,4 +18,4 @@ type ConsoleLogger(name: string) =
             Console.WriteLine(message)
 
         member this.IsEnabled(logLevel: LogLevel) = true
-        member this.BeginScope(var0) = failwith "Not implemented"
+        member this.BeginScope(_) = failwith "Not implemented"

--- a/src/Fable.Logging/Fable.Logging.fsproj
+++ b/src/Fable.Logging/Fable.Logging.fsproj
@@ -7,7 +7,7 @@
     <Copyright>Dag Brattli</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <WarnOn>3390;$(WarnOn)</WarnOn>
-    <PackageTags>fsharp;fable;fable-library;logging;ilogger</PackageTags>
+    <PackageTags>fsharp;fable;fable-library;fable-javascript;fable-python;fable-beam;logging;ilogger</PackageTags>
     <Description>Cross-platform logging framework for Fable with ILogger, ILoggerFactory, and ILoggerProvider interfaces</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fable.Logging/ILogger.fs
+++ b/src/Fable.Logging/ILogger.fs
@@ -14,25 +14,22 @@ type LogLevel =
     | Warning = 3
 
 type LogState =
-    {
-        Level: LogLevel
-        Format: string
-        Args: obj array
-        Exception: exn option
-    }
+    { Level: LogLevel
+      Format: string
+      Args: obj array
+      Exception: exn option }
 
-    static member Create(level: LogLevel, format: string, ?parameters: obj array, ?error: exn) = {
-        Level = level
-        Format = format
-        Args = defaultArg parameters [||]
-        Exception = error
-    }
+    static member Create(level: LogLevel, format: string, ?parameters: obj array, ?error: exn) =
+        { Level = level
+          Format = format
+          Args = defaultArg parameters [||]
+          Exception = error }
 
 type ILogger =
     abstract member Log: LogState -> unit
     abstract member IsEnabled: logLevel: LogLevel -> bool
 
-    abstract member BeginScope: obj -> ILogger
+    abstract member BeginScope: obj -> IDisposable
 
 type ILoggerProvider =
     inherit IDisposable
@@ -90,6 +87,11 @@ module Extensions =
         member this.LogInformation(message: string, [<ParamArray>] parameters: obj[]) =
             if this.IsEnabled LogLevel.Information then
                 LogState.Create(LogLevel.Information, message, parameters)
+                |> this.Log
+
+        member this.LogTrace(message: string, [<ParamArray>] parameters: obj[]) =
+            if this.IsEnabled LogLevel.Trace then
+                LogState.Create(LogLevel.Trace, message, parameters)
                 |> this.Log
 
         member this.LogCritical(message: string, [<ParamArray>] parameters: obj[]) =

--- a/src/Fable.Logging/JSLogger.fs
+++ b/src/Fable.Logging/JSLogger.fs
@@ -36,7 +36,7 @@ type Logger(name: string) =
                 | _ -> console.log (message)
 
         member x.IsEnabled(logLevel: LogLevel) = logLevel >= x.MinimumLevel
-        member _.BeginScope(_) = failwith "Not implemented"
+        member _.BeginScope(_) : System.IDisposable = failwith "Not implemented"
 
 type LoggerProvider() =
     interface ILoggerProvider with

--- a/src/Fable.Logging/LoggerFactory.fs
+++ b/src/Fable.Logging/LoggerFactory.fs
@@ -18,8 +18,9 @@ type internal Logger(name: string, providers: ResizeArray<ILoggerProvider>, mini
                 |> Seq.iter (fun l -> l.Log state)
 
         member x.IsEnabled(logLevel: LogLevel) =
-            loggers
-            |> Seq.exists (fun l -> l.IsEnabled logLevel)
+            logLevel >= minimumLevel
+            && loggers
+               |> Seq.exists (fun l -> l.IsEnabled logLevel)
 
         member _.BeginScope(state: obj) = failwith "Not implemented"
 

--- a/test/TestUtils.fs
+++ b/test/TestUtils.fs
@@ -25,7 +25,7 @@ type MockLogger(name: string) =
         member x.IsEnabled(logLevel: Fable.Logging.LogLevel) =
             logLevel >= x.MinimumLevel
 
-        member _.BeginScope(_) = failwith "Not implemented"
+        member _.BeginScope(_) : System.IDisposable = failwith "Not implemented"
 
 type MockLoggerProvider() =
     let loggers = ResizeArray<MockLogger>()


### PR DESCRIPTION
## Summary

- **Align with .NET logging abstractions**: Fix `BeginScope` return type (`ILogger` → `IDisposable`), fix `IsEnabled` to respect minimum level, add missing `LogTrace`, fix ConsoleLogger double-formatting bug
- **Fix minor provider issues**: Map Structlog Trace to debug instead of info, remove redundant error match in BeamLogger
- **Add platform tags** to core NuGet package (`fable-javascript`, `fable-python`, `fable-beam`)
- **Rewrite README** with introduction, examples for all platforms, and API reference

## Test plan

- [x] `just build` passes (all 4 projects)
- [x] `dotnet run --project test` — 49/49 tests pass
- [x] `just format-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)