### PR TITLE
ci: add conventional PR title enforcement

### DIFF
--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -1,0 +1,27 @@
+name: conventional-pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            ci
+            build
+            revert


### PR DESCRIPTION
## Summary
- Add workflow to enforce conventional commit format on PR titles using `amannn/action-semantic-pull-request@v6`
- Ensures ShipIt can parse merge commits and create release PRs (fixes the `FailedToParseCommit` errors)

## Test plan
- [x] Verify workflow matches Fable.Beam's `conventional-pr-title.yml`
- [ ] Merge and confirm next feature PR triggers a ShipIt release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)