### PR TITLE
chore: set last_commit_released in changelogs

### DIFF
--- a/src/Fable.Logging.Beam/CHANGELOG.md
+++ b/src/Fable.Logging.Beam/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+last_commit_released: dee954875171b098225b5970a25134aa74ec73a0
 name: Fable.Logging.Beam
 ---
 

--- a/src/Fable.Logging.Structlog/CHANGELOG.md
+++ b/src/Fable.Logging.Structlog/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+last_commit_released: dee954875171b098225b5970a25134aa74ec73a0
 name: Fable.Logging.Structlog
 ---
 

--- a/src/Fable.Logging/CHANGELOG.md
+++ b/src/Fable.Logging/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+last_commit_released: dee954875171b098225b5970a25134aa74ec73a0
 name: Fable.Logging
 ---
 


### PR DESCRIPTION
## Summary
- Add `last_commit_released` to all three changelog frontmatters, pointing to current main HEAD
- This tells ShipIt to only scan commits after this point, skipping old non-conventional merge commits that cause `FailedToParseCommit` errors

## Test plan
- [ ] Merge and verify the next feature PR triggers a ShipIt release PR successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)