### PR TITLE
fix: add paket install to release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,10 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
-      - name: Install tools
+      - name: Install tools and restore
         run: |
           dotnet tool restore
+          dotnet paket install
           dotnet restore src/Fable.Logging
           dotnet restore src/Fable.Logging.Structlog
           dotnet restore src/Fable.Logging.Beam


### PR DESCRIPTION
## Summary
- Add `dotnet paket install` before `dotnet restore` in the release job
- Fixes `MSB4019: The imported project ".paket/Paket.Restore.targets" was not found` error

## Test plan
- [ ] Merge and verify the release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)