### PR TITLE
chore: release multiple projects

### DIFF
--- a/src/Fable.Logging.Beam/CHANGELOG.md
+++ b/src/Fable.Logging.Beam/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-last_commit_released: d8b9c80c23d044fffac2adf446469121a2c71f4d
+last_commit_released: 435d19209695cbce5c1ee398c756aeb51c3dc71d
 name: Fable.Logging.Beam
 ---
 

--- a/src/Fable.Logging.Structlog/CHANGELOG.md
+++ b/src/Fable.Logging.Structlog/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-last_commit_released: d8b9c80c23d044fffac2adf446469121a2c71f4d
+last_commit_released: 435d19209695cbce5c1ee398c756aeb51c3dc71d
 name: Fable.Logging.Structlog
 ---
 

--- a/src/Fable.Logging/CHANGELOG.md
+++ b/src/Fable.Logging/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-last_commit_released: d8b9c80c23d044fffac2adf446469121a2c71f4d
+last_commit_released: 435d19209695cbce5c1ee398c756aeb51c3dc71d
 name: Fable.Logging
 ---
 


### PR DESCRIPTION
## 🤖 New versions available

| Project | Status | New Version |
| --- | :---: | :---: |
| Fable.Logging | 🚀 | 0.11.0 |
| Fable.Logging.Beam | 🚀 | 0.11.0 |
| Fable.Logging.Structlog | 🚀 | 0.11.0 |

**Legend:**
- ✅ No version bump required
- 🚀 New version

## Fable.Logging

### 0.11.0 - 2026-03-28

### 🚀 Features

* modernize repo with multi-package structure and updated tooling (#2)

### 🐞 Bug Fixes

* align logging interfaces with .NET abstractions and rewrite README (#3)

## Fable.Logging.Beam

### 0.11.0 - 2026-03-28

### 🚀 Features

* modernize repo with multi-package structure and updated tooling (#2)

### 🐞 Bug Fixes

* align logging interfaces with .NET abstractions and rewrite README (#3)

## Fable.Logging.Structlog

### 0.11.0 - 2026-03-28

### 🚀 Features

* modernize repo with multi-package structure and updated tooling (#2)

### 🐞 Bug Fixes

* align logging interfaces with .NET abstractions and rewrite README (#3)

---
This PR was created manually to bootstrap the first ShipIt release.