### PR TITLE
fix: add PackageReadmeFile to NuGet packages

### DIFF
--- a/src/Fable.Logging.Beam/Fable.Logging.Beam.fsproj
+++ b/src/Fable.Logging.Beam/Fable.Logging.Beam.fsproj
@@ -9,6 +9,7 @@
     <WarnOn>3390;$(WarnOn)</WarnOn>
     <PackageTags>fsharp;fable;fable-beam;erlang;otp;logging</PackageTags>
     <Description>Fable.Logging provider for Erlang/OTP logger on BEAM</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BeamLogger.fs" />

--- a/src/Fable.Logging.Structlog/Fable.Logging.Structlog.fsproj
+++ b/src/Fable.Logging.Structlog/Fable.Logging.Structlog.fsproj
@@ -9,6 +9,7 @@
     <WarnOn>3390;$(WarnOn)</WarnOn>
     <PackageTags>fsharp;fable;fable-library;fable-python;logging;structlog</PackageTags>
     <Description>Fable.Logging provider for Python structlog</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <PropertyGroup>
     <PythonDependencies>

--- a/src/Fable.Logging/Fable.Logging.fsproj
+++ b/src/Fable.Logging/Fable.Logging.fsproj
@@ -9,6 +9,7 @@
     <WarnOn>3390;$(WarnOn)</WarnOn>
     <PackageTags>fsharp;fable;fable-library;fable-javascript;fable-python;fable-beam;logging;ilogger</PackageTags>
     <Description>Cross-platform logging framework for Fable with ILogger, ILoggerFactory, and ILoggerProvider interfaces</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ILogger.fs" />


### PR DESCRIPTION
## Summary
- Add `<PackageReadmeFile>README.md</PackageReadmeFile>` to all three fsproj files
- The README.md was already included in the package but NuGet wasn't told to use it as the readme

## Test plan
- [ ] Verify next `dotnet pack` no longer warns about missing readme

🤖 Generated with [Claude Code](https://claude.com/claude-code)