### PR TITLE
fix: remove pre-release flag from ShipIt

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         run: dotnet tool restore
 
       - name: ShipIt (Pull Request)
-        run: dotnet shipit --pre-release rc
+        run: dotnet shipit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Remove `--pre-release rc` from the ShipIt command so releases use stable versions instead of `-rc.N` suffixes

## Test plan
- [ ] Merge and verify next ShipIt release PR proposes stable versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)