### PR TITLE
feat: sync Erlang OTP logger primary level from LoggerProvider

### DIFF
--- a/src/Fable.Logging.Beam/BeamLogger.fs
+++ b/src/Fable.Logging.Beam/BeamLogger.fs
@@ -1,6 +1,20 @@
 module Fable.Logging.Beam
 
+open Fable.Core
 open Fable.Beam
+
+[<Emit("logger:set_primary_config(level, $0)")>]
+let private setPrimaryLevel (_level: obj) : unit = nativeOnly
+
+let private toErlangLevel (level: LogLevel) =
+    match level with
+    | LogLevel.Trace
+    | LogLevel.Debug -> "debug"
+    | LogLevel.Information -> "info"
+    | LogLevel.Warning -> "warning"
+    | LogLevel.Error -> "error"
+    | LogLevel.Critical -> "critical"
+    | _ -> "info"
 
 type Logger(name: string) =
 
@@ -24,7 +38,15 @@ type Logger(name: string) =
         member x.IsEnabled(logLevel: LogLevel) = logLevel >= x.MinimumLevel
         member _.BeginScope(_) : System.IDisposable = failwith "Not implemented"
 
-type LoggerProvider() =
+type LoggerProvider(?minimumLevel: LogLevel) =
+    let level = defaultArg minimumLevel LogLevel.Trace
+
+    do setPrimaryLevel (toErlangLevel level)
+
     interface ILoggerProvider with
-        member _.CreateLogger(name) = Logger(name)
+        member _.CreateLogger(name) =
+            let logger = Logger(name)
+            logger.MinimumLevel <- level
+            logger
+
         member _.Dispose() = ()


### PR DESCRIPTION
## Summary
- Erlang's logger defaults to `notice` level, silently dropping `info` and `debug` messages
- Add `logger:set_primary_config(level, ...)` call during `LoggerProvider` initialization to sync the OTP logger level
- `LoggerProvider` now accepts an optional `minimumLevel` parameter and propagates it to created loggers
- Uses inline `[<Emit>]` since `Fable.Beam.Logger` doesn't expose `set_primary_config` yet

## Test plan
- [ ] Create a `LoggerProvider()` and verify `LogInformation` produces output without manual Erlang config
- [ ] Create a `LoggerProvider(LogLevel.Warning)` and verify info/debug messages are suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)