### PR TITLE
feat: upgrade Fable.Beam to 5.0.0-rc.19 and sync OTP logger level

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
 nuget Fable.Core 5.0.0-rc.1
-nuget Fable.Beam 5.0.0-rc.17
+nuget Fable.Beam 5.0.0-rc.19
 
 group Test
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Beam (5.0.0-rc.17)
+    Fable.Beam (5.0.0-rc.19)
       Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 5.0)
     Fable.Core (5.0.0-rc.1)

--- a/src/Fable.Logging.Beam/BeamLogger.fs
+++ b/src/Fable.Logging.Beam/BeamLogger.fs
@@ -1,6 +1,17 @@
 module Fable.Logging.Beam
 
 open Fable.Beam
+open Fable.Beam.Erlang
+
+let private toErlangLevel (level: LogLevel) =
+    match level with
+    | LogLevel.Trace
+    | LogLevel.Debug -> Atom "debug"
+    | LogLevel.Information -> Atom "info"
+    | LogLevel.Warning -> Atom "warning"
+    | LogLevel.Error -> Atom "error"
+    | LogLevel.Critical -> Atom "critical"
+    | _ -> Atom "info"
 
 type Logger(name: string) =
 
@@ -24,7 +35,15 @@ type Logger(name: string) =
         member x.IsEnabled(logLevel: LogLevel) = logLevel >= x.MinimumLevel
         member _.BeginScope(_) : System.IDisposable = failwith "Not implemented"
 
-type LoggerProvider() =
+type LoggerProvider(?minimumLevel: LogLevel) =
+    let level = defaultArg minimumLevel LogLevel.Trace
+
+    do Logger.logger.set_primary_config ("level", toErlangLevel level)
+
     interface ILoggerProvider with
-        member _.CreateLogger(name) = Logger(name)
+        member _.CreateLogger(name) =
+            let logger = Logger(name)
+            logger.MinimumLevel <- level
+            logger
+
         member _.Dispose() = ()


### PR DESCRIPTION
## Summary
- Upgrade Fable.Beam from 5.0.0-rc.17 to 5.0.0-rc.19
- Use the new `set_primary_config` binding to set the Erlang logger primary level during `LoggerProvider` initialization
- Erlang's logger defaults to `notice`, silently dropping `info` and `debug` — this makes it just work
- `LoggerProvider` now accepts an optional `minimumLevel` parameter
- Supersedes #13 (uses proper Fable.Beam binding instead of inline `[<Emit>]`)

## Test plan
- [x] All 49 tests pass
- [ ] Verify on BEAM that `LogInformation` produces output without manual Erlang config

🤖 Generated with [Claude Code](https://claude.com/claude-code)