### PR TITLE
fix: relax dependency version constraints

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,8 +5,8 @@ storage: none
 framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
-nuget Fable.Core 5.0.0-rc.1
-nuget Fable.Beam 5.0.0-rc.19
+nuget Fable.Core >= 5.0.0-rc.1
+nuget Fable.Beam >= 5.0.0-rc.19
 
 group Test
     source https://api.nuget.org/v3/index.json
@@ -14,4 +14,4 @@ group Test
     framework: net10.0
 
     nuget FSharp.Core
-    nuget Fable.Core 5.0.0-rc.1
+    nuget Fable.Core >= 5.0.0-rc.1


### PR DESCRIPTION
## Summary
- Use `>=` instead of exact versions for `Fable.Core` and `Fable.Beam` dependencies in `paket.dependencies`
- Prevents version conflicts in downstream consumers (e.g. `Fable.Logging.Beam` pinning `Fable.Beam 5.0.0-rc.19` while dependents need `5.0.0-rc.20`)

## Test plan
- [x] `just restore` succeeds
- [x] `just build` succeeds with all projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)