### PR TITLE
fix: use Atom key in set_primary_config for Fable.Beam rc.20

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
 nuget Fable.Core >= 5.0.0-rc.1
-nuget Fable.Beam >= 5.0.0-rc.19
+nuget Fable.Beam >= 5.0.0-rc.20
 
 group Test
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Beam (5.0.0-rc.19)
+    Fable.Beam (5.0.0-rc.20)
       Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 5.0)
     Fable.Core (5.0.0-rc.1)

--- a/src/Fable.Logging.Beam/BeamLogger.fs
+++ b/src/Fable.Logging.Beam/BeamLogger.fs
@@ -38,7 +38,7 @@ type Logger(name: string) =
 type LoggerProvider(?minimumLevel: LogLevel) =
     let level = defaultArg minimumLevel LogLevel.Trace
 
-    do Logger.logger.set_primary_config ("level", toErlangLevel level)
+    do Logger.logger.set_primary_config (Atom "level", toErlangLevel level)
 
     interface ILoggerProvider with
         member _.CreateLogger(name) =


### PR DESCRIPTION
## Summary
- `Fable.Beam 5.0.0-rc.20` changed `set_primary_config` to expect `Atom` keys instead of `string`
- Update `"level"` to `Atom "level"` in `BeamLogger.fs` to fix compatibility
- Update `paket.lock` to resolve `Fable.Beam 5.0.0-rc.20`

## Test plan
- [x] `just build` passes for all projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)