### PR TITLE
fix: upgrade Fable.Beam to 5.0.0-rc.22 and qualify Logger module

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
 nuget Fable.Core >= 5.0.0-rc.1
-nuget Fable.Beam >= 5.0.0-rc.20
+nuget Fable.Beam >= 5.0.0-rc.22
 
 group Test
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -2,7 +2,7 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Beam (5.0.0-rc.20)
+    Fable.Beam (5.0.0-rc.22)
       Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 5.0)
     Fable.Core (5.0.0-rc.1)

--- a/src/Fable.Logging.Beam/BeamLogger.fs
+++ b/src/Fable.Logging.Beam/BeamLogger.fs
@@ -1,7 +1,6 @@
 module Fable.Logging.Beam
 
 open Fable.Beam
-open Fable.Beam.Erlang
 
 let private toErlangLevel (level: LogLevel) =
     match level with
@@ -25,12 +24,12 @@ type Logger(name: string) =
                 let message, _ = Common.translateFormat name state.Format state.Args
 
                 match level with
-                | LogLevel.Debug -> Logger.logger.debug (message)
-                | LogLevel.Information -> Logger.logger.info (message)
-                | LogLevel.Warning -> Logger.logger.warning (message)
-                | LogLevel.Error -> Logger.logger.error (message)
-                | LogLevel.Critical -> Logger.logger.critical (message)
-                | _ -> Logger.logger.info (message)
+                | LogLevel.Debug -> Fable.Beam.Logger.logger.debug (message)
+                | LogLevel.Information -> Fable.Beam.Logger.logger.info (message)
+                | LogLevel.Warning -> Fable.Beam.Logger.logger.warning (message)
+                | LogLevel.Error -> Fable.Beam.Logger.logger.error (message)
+                | LogLevel.Critical -> Fable.Beam.Logger.logger.critical (message)
+                | _ -> Fable.Beam.Logger.logger.info (message)
 
         member x.IsEnabled(logLevel: LogLevel) = logLevel >= x.MinimumLevel
         member _.BeginScope(_) : System.IDisposable = failwith "Not implemented"
@@ -38,7 +37,7 @@ type Logger(name: string) =
 type LoggerProvider(?minimumLevel: LogLevel) =
     let level = defaultArg minimumLevel LogLevel.Trace
 
-    do Logger.logger.set_primary_config (Atom "level", toErlangLevel level)
+    do Fable.Beam.Logger.logger.set_primary_config (Atom "level", toErlangLevel level)
 
     interface ILoggerProvider with
         member _.CreateLogger(name) =


### PR DESCRIPTION
## Summary
- Upgrade Fable.Beam from 5.0.0-rc.20 to 5.0.0-rc.22 which fixes `set_primary_config` to accept `Atom` key
- Remove `open Fable.Beam.Erlang` (Atom moved to `Fable.Beam` namespace)
- Qualify `Fable.Beam.Logger.logger` calls to avoid shadowing by our `Logger` type

## Test plan
- [x] All 49 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)