### PR TITLE
chore: upgrade EasyBuild.ShipIt to 3.0.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "easybuild.shipit": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "commands": [
         "shipit"
       ],

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
   shipit-pr:
     name: ShipIt - Pull Request
     runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'chore: release ')"
     timeout-minutes: 10
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ---
 last_commit_released: a39accdd5ec96a5e2d3117d1dd0e2eef4fd1d252
+name: Fable.Logging
 ---
 
 # Changelog

--- a/justfile
+++ b/justfile
@@ -63,4 +63,4 @@ restore:
 
 # Run EasyBuild.ShipIt for release management
 shipit *args:
-    dotnet shipit --pre-release rc {{args}}
+    dotnet shipit {{args}}


### PR DESCRIPTION
## Summary
- Bump `easybuild.shipit` 2.0.0 → 3.0.0 in `.config/dotnet-tools.json`
- Drop hardcoded `--pre-release rc` from `just shipit` so default runs cut stable releases (use `just shipit --pre-release rc` when an rc is wanted)
- Add `name: Fable.Logging` to `CHANGELOG.md` frontmatter
- Add `if: !startsWith(... 'chore: release ')` guard to the `shipit-pr` job in `publish.yml` so ShipIt doesn't re-run on its own release commits

Aligns this repo's release setup with [Fable.Python](https://github.com/fable-compiler/Fable.Python).

## Test plan
- [ ] `dotnet tool restore` pulls ShipIt 3.0.0 cleanly
- [ ] `just shipit` (locally or via CI) produces a non-rc version proposal
- [ ] After merging a `chore: release` PR, the `shipit-pr` job is skipped and only the `release` job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)