### PR TITLE
fix: upgrade Fable.Beam to 5.0.0-rc.32

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
 nuget Fable.Core >= 5.0.0-rc.1
-nuget Fable.Beam >= 5.0.0-rc.22
+nuget Fable.Beam >= 5.0.0-rc.32
 
 group Test
     source https://api.nuget.org/v3/index.json

--- a/paket.lock
+++ b/paket.lock
@@ -2,8 +2,8 @@ STORAGE: NONE
 RESTRICTION: == netstandard2.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Beam (5.0.0-rc.22)
-      Fable.Core (5.0.0-rc.1)
+    Fable.Beam (5.0.0-rc.32)
+      Fable.Core (>= 5.0)
       FSharp.Core (>= 5.0)
     Fable.Core (5.0.0-rc.1)
       FSharp.Core (>= 4.7.2)

--- a/src/Fable.Logging.Beam/BeamLogger.fs
+++ b/src/Fable.Logging.Beam/BeamLogger.fs
@@ -37,7 +37,7 @@ type Logger(name: string) =
 type LoggerProvider(?minimumLevel: LogLevel) =
     let level = defaultArg minimumLevel LogLevel.Trace
 
-    do Fable.Beam.Logger.logger.set_primary_config (Atom "level", toErlangLevel level)
+    do Fable.Beam.Logger.logger.set_primary_config (Atom "level", toErlangLevel level) |> ignore
 
     interface ILoggerProvider with
         member _.CreateLogger(name) =


### PR DESCRIPTION
## Summary
- Bump `Fable.Beam` from `5.0.0-rc.22` to `5.0.0-rc.32` (`paket.dependencies` + `paket.lock`)
- Add `|> ignore` to the `set_primary_config` call in `BeamLogger.fs:40` — rc.32 changed that signature from `unit` to `Result`, breaking the `do`-binding in `LoggerProvider`

This is the sole call site rc.32 broke in `Fable.Logging.Beam`. The other RC-hardened signatures (`add_primary_filter` raw, `update_handler_config`) also went `unit → Result`, but they aren't used here.

## Test plan
- `just test` → 49/49 tests pass, including the Beam logger suite that exercises the changed call site

🤖 Generated with [Claude Code](https://claude.com/claude-code)