### PR TITLE
fix: Upgrade to Fable 5.4 and drop unnecessary arg boxing

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "fable": {
-      "version": "5.0.0-rc.3",
+      "version": "5.4.0",
       "commands": [
         "fable"
       ],

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ let factory =
 let logger = factory.CreateLogger("MyApp.Service")
 
 logger.LogInformation("Application started")
-logger.LogDebug("Processing request for {UserId}", box 42)
+logger.LogDebug("Processing request for {UserId}", 42)
 logger.LogError("Something went wrong")
 ```
 
@@ -48,7 +48,7 @@ let factory =
         builder.AddProvider(LoggerProvider()))
 
 let logger = factory.CreateLogger("MyApp")
-logger.LogInformation("Hello from {Platform}!", box "JavaScript")
+logger.LogInformation("Hello from {Platform}!", "JavaScript")
 ```
 
 ### Python (structlog)
@@ -71,7 +71,7 @@ let jsonFactory =
         builder.AddProvider(JsonLoggerProvider()))
 
 let logger = factory.CreateLogger("MyApp")
-logger.LogInformation("User {Name} logged in", box "Alice")
+logger.LogInformation("User {Name} logged in", "Alice")
 ```
 
 ### Erlang/BEAM (OTP logger)
@@ -87,7 +87,7 @@ let factory =
         builder.AddProvider(LoggerProvider()))
 
 let logger = factory.CreateLogger("MyApp")
-logger.LogWarning("Connection pool running low: {Available} remaining", box 3)
+logger.LogWarning("Connection pool running low: {Available} remaining", 3)
 ```
 
 ## Log Levels
@@ -125,7 +125,7 @@ Use named placeholders in log messages for structured logging. The placeholder n
 become keys in the structured log output, while values are substituted positionally:
 
 ```fsharp
-logger.LogInformation("Order {OrderId} placed by {Customer}", box 1234, box "Alice")
+logger.LogInformation("Order {OrderId} placed by {Customer}", 1234, "Alice")
 // Output: MyApp - Order 1234 placed by Alice
 ```
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -5,7 +5,7 @@ storage: none
 framework: netstandard2.0
 
 nuget FSharp.Core >= 5.0.0 lowest_matching: true
-nuget Fable.Core >= 5.0.0-rc.1
+nuget Fable.Core >= 5.1.0
 nuget Fable.Beam >= 5.0.0-rc.32
 
 group Test
@@ -14,4 +14,4 @@ group Test
     framework: net10.0
 
     nuget FSharp.Core
-    nuget Fable.Core >= 5.0.0-rc.1
+    nuget Fable.Core >= 5.1.0

--- a/paket.lock
+++ b/paket.lock
@@ -5,7 +5,7 @@ NUGET
     Fable.Beam (5.0.0-rc.32)
       Fable.Core (>= 5.0)
       FSharp.Core (>= 5.0)
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (5.0)
 
@@ -14,6 +14,6 @@ STORAGE: NONE
 RESTRICTION: == net10.0
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Fable.Core (5.0.0-rc.1)
+    Fable.Core (5.1)
       FSharp.Core (>= 4.7.2)
     FSharp.Core (11.0.100)

--- a/test/TestBeamLogger.fs
+++ b/test/TestBeamLogger.fs
@@ -49,7 +49,7 @@ let ``test Beam logger logs with format args`` () =
     let provider = LoggerProvider()
     let factory = LoggerFactory.Create(fun builder -> builder.AddProvider(provider))
     let logger = factory.CreateLogger("beam-test")
-    logger.LogInformation("hello {name}", box "World")
+    logger.LogInformation("hello {name}", "World")
 #else
     ()
 #endif

--- a/test/TestConsoleLogger.fs
+++ b/test/TestConsoleLogger.fs
@@ -26,4 +26,4 @@ let ``test ConsoleLogger logs without error`` () =
 let ``test ConsoleLogger logs with format args`` () =
     let logger = ConsoleLogger("test") :> ILogger
     // ConsoleLogger uses String.Format internally, so use indexed placeholders
-    logger.Log(LogLevel.Information, "hello {0}", box "World")
+    logger.Log(LogLevel.Information, "hello {0}", "World")

--- a/test/TestExtensions.fs
+++ b/test/TestExtensions.fs
@@ -81,7 +81,7 @@ let ``test LogDebug with format args`` () =
     let provider = new MockLoggerProvider()
     let factory = LoggerFactory.Create(fun builder -> builder.AddProvider(provider))
     let logger = factory.CreateLogger("test")
-    logger.LogInformation("hello {name}", box "World")
+    logger.LogInformation("hello {name}", "World")
     let log = provider.Loggers.[0].Logs.[0]
     log.Format |> equal "hello {name}"
     log.Args.Length |> equal 1

--- a/test/TestJSLogger.fs
+++ b/test/TestJSLogger.fs
@@ -49,7 +49,7 @@ let ``test JS logger logs with format args`` () =
     let provider = LoggerProvider()
     let factory = LoggerFactory.Create(fun builder -> builder.AddProvider(provider))
     let logger = factory.CreateLogger("js-test")
-    logger.LogInformation("hello {name}", box "World")
+    logger.LogInformation("hello {name}", "World")
 #else
     ()
 #endif

--- a/test/TestLogLevel.fs
+++ b/test/TestLogLevel.fs
@@ -51,4 +51,4 @@ let ``test LogState.Create with parameters`` () =
 let ``test LogState.Create with exception`` () =
     let ex = System.Exception("test error")
     let state = LogState.Create(LogLevel.Error, "failed", error = ex)
-    state.Exception |> equal (Some ex)
+    state.Exception |> equal (Some (ex :> exn))

--- a/test/TestStructlog.fs
+++ b/test/TestStructlog.fs
@@ -44,7 +44,7 @@ let ``test Structlog logger logs with format args`` () =
     let provider = ConsoleLoggerProvider()
     let factory = LoggerFactory.Create(fun builder -> builder.AddProvider(provider))
     let logger = factory.CreateLogger("test")
-    logger.LogInformation("hello {name}", box "World")
+    logger.LogInformation("hello {name}", "World")
 #else
     ()
 #endif


### PR DESCRIPTION
## Summary
- Upgrade the `fable` tool from `5.0.0-rc.3` to **`5.4.0`** and `Fable.Core` from `5.0.0-rc.1` to the **`5.1.0`** stable release (both dependency groups).
- Drop the explicit `box` at log call sites in the README examples and tests.

## Why drop the boxing
Downstream users flagged that having to write `logger.LogInformation("Hello {Platform}!", box "JS")` is awkward. It turns out the `box` was never required: F# auto-boxes `[<ParamArray>] obj[]` arguments, and Fable compiles the coercion to a no-op. Verified by transpiling real usage **without** `box` on JS, Python, and Rust backends — args pass straight through (`LogDebug(..., 42, 7)`).

The `box` was not a Beam requirement or an API constraint — it was cosmetic ceremony introduced when the test suite and README were authored (commit `10b0453`), and consumers were copying it from the docs. The `[<ParamArray>] obj[]` API itself is unchanged.

## Notes
- Also upcasts the expected exception to `exn` in `TestLogLevel` so the comparison matches the `exn option` field.
- No public API/signature changes — non-breaking.

## Verification
- `just test` → **49/49 tests pass**
- Fable 5.4 transpiles the library to JS and Python with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)